### PR TITLE
glue.c: update to new uk_alloc_init_malloc interface

### DIFF
--- a/glue.c
+++ b/glue.c
@@ -32,6 +32,7 @@
 
 #include <uk/tlsf.h>
 #include <uk/alloc_impl.h>
+#include <stdint.h> /* uintptr_t */
 #include <tlsf.h>
 
 /* malloc interface */
@@ -71,7 +72,8 @@ struct uk_alloc *uk_tlsf_init(void *base, size_t len)
 	if (res == (size_t)-1)
 		return NULL;
 
-	uk_alloc_init_malloc_ifmalloc(a, uk_tlsf_malloc, uk_tlsf_free, NULL);
+	uk_alloc_init_malloc_ifmalloc(a, uk_tlsf_malloc, uk_tlsf_free,
+		NULL /* maxalloc */, NULL /* availmem */, NULL /* addmem */);
 
 	return a;
 }

--- a/include/uk/tlsf.h
+++ b/include/uk/tlsf.h
@@ -34,6 +34,7 @@
 #define __LIBTLSF_H__
 
 #include <uk/alloc.h>
+#include <stddef.h> /* `NULL` and `size_t` */
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
The uk_alloc_init_malloc interface has been updated with maxalloc and
availmem. We must update calls accordingly.

Signed-off-by: Hugo Lefeuvre <hugo.lefeuvre@manchester.ac.uk>