### PR TITLE
Introduce Library.uk

### DIFF
--- a/Library.uk
+++ b/Library.uk
@@ -1,0 +1,5 @@
+name        := "tlsf"
+description := "A general purpose dynamic memory allocator specifically designed to meet real-time requirements."
+homepage    := "http://www.gii.upv.es/tlsf/"
+license     := "LGPL-2.0"
+version     := 2.4.6 sha256:43fa1f8e468d39723616b2954dc35c4cc7860fcb05565906fbe6887423a18c74 https://web.archive.org/web/20190717034200if_/http://wks.gii.upv.es:80/tlsf/files/src/TLSF-2.4.6.tbz2


### PR DESCRIPTION
This new file represents the first step towards proper versioning support of external microlibrary in Unikraft.  The file itself acts as mechanism for holding metadata-only values about the microlibrary.  This metadata is designed to be compatible with GNU Make whilst simultaneously being human-readable and readable by programs that are not GNU Make (e.g. tools such as KraftKit).

An important feature of this file is the inclusion of microlibrary versions. In a later step, once relevant integrations have been made to Unikrat's core build system and to relevant tools such as KraftKit, the user will be able to see and select from different versions of the microlibrary.

In this initial commit, the relevant metadata is absorbed from both Makefile.uk, Config.uk, but also includes new information such as SPDX License identifier. 

